### PR TITLE
Remove cluster url as we print this from spark_ec2

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -127,5 +127,3 @@ for module in $MODULES; do
   source ./$module/setup.sh
   sleep 1
 done
-
-echo "Cluster is started at http://$PUBLIC_DNS:8080"


### PR DESCRIPTION
spark_ec2.py change at https://github.com/mesos/spark/pull/477
