### PR TITLE
Fix ganglia graphs

### DIFF
--- a/ganglia/init.sh
+++ b/ganglia/init.sh
@@ -4,6 +4,10 @@
 rm -rf /var/lib/ganglia/rrds/*
 rm -rf /mnt/ganglia/rrds/*
 
+# Symlink /var/lib/ganglia/rrds to /mnt/ganglia/rrds
+rmdir /var/lib/ganglia/rrds
+ln -s /mnt/ganglia/rrds /var/lib/ganglia/rrds
+
 # Make sure rrd storage directory has right permissions
 mkdir -p /mnt/ganglia/rrds
 chown -R nobody:nobody /mnt/ganglia/rrds


### PR DESCRIPTION
The graphs were broken after we changed the ganglia rrd storage location. This change fixes them by symlinking /var/lib/ganglia/rrds. Screenshot of graphs after the change.

![ganglia-screenshot](https://f.cloud.github.com/assets/143893/784198/5c7727c2-ea5f-11e2-8fa7-ac8611cb7a38.png)
