### PR TITLE
Set HADOOP_HOME and HADOOP_MAPREDUCE_HOME in all config files

### DIFF
--- a/templates/root/ephemeral-hdfs/conf/hadoop-env.sh
+++ b/templates/root/ephemeral-hdfs/conf/hadoop-env.sh
@@ -11,6 +11,9 @@ export JAVA_HOME={{java_home}}
 # Extra Java CLASSPATH elements.  Optional.
 # export HADOOP_CLASSPATH=
 
+export HADOOP_HOME="/root/ephemeral-hdfs"
+export HADOOP_MAPREDUCE_HOME="/root/mapreduce"
+
 # The maximum amount of heap to use, in MB. Default is 1000.
 export HADOOP_HEAPSIZE=1000
 

--- a/templates/root/mapreduce/conf/hadoop-env.sh
+++ b/templates/root/mapreduce/conf/hadoop-env.sh
@@ -11,6 +11,9 @@ export JAVA_HOME=/usr/lib/jvm/java-1.7.0
 # Extra Java CLASSPATH elements.  Optional.
 # export HADOOP_CLASSPATH=
 
+export HADOOP_HOME="/root/ephemeral-hdfs"
+export HADOOP_MAPREDUCE_HOME="/root/mapreduce"
+
 # The maximum amount of heap to use, in MB. Default is 1000.
 export HADOOP_HEAPSIZE=1000
 

--- a/templates/root/persistent-hdfs/conf/hadoop-env.sh
+++ b/templates/root/persistent-hdfs/conf/hadoop-env.sh
@@ -8,6 +8,9 @@
 # The java implementation to use.  Required.
 export JAVA_HOME={{java_home}}
 
+export HADOOP_HOME="/root/persistent-hdfs"
+export HADOOP_MAPREDUCE_HOME="/root/mapreduce"
+
 # Extra Java CLASSPATH elements.  Optional.
 # export HADOOP_CLASSPATH=
 


### PR DESCRIPTION
Setting `HADOOP_MAPREDUCE_HOME` is necessary to get distcp to work correctly with Hadoop2. Setting `HADOOP_HOME` helps fix the case where a user has set their own `HADOOP_HOME` which doesn't match that expected by the scripts they are calling.
