### PR TITLE
Set SPARK_PUBLIC_DNS in spark-env.sh and .bash_profile

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -132,6 +132,10 @@ echo "Deploying Spark config files..."
 chmod u+x /root/spark/conf/spark-env.sh
 /root/spark-ec2/copy-dir /root/spark/conf
 
+# Add SPARK_PUBLIC_DNS to bash_profile to have it be found by user apps
+SPARK_PUBLIC_DNS=`wget -q -O - http://instance-data.ec2.internal/latest/meta-data/public-hostname`
+echo "export SPARK_PUBLIC_DNS=$SPARK_PUBLIC_DNS" >> ~/.bash_profile
+
 # Setup each module
 for module in $MODULES; do
   echo "Setting up $module"

--- a/templates/root/spark/conf/spark-env.sh
+++ b/templates/root/spark/conf/spark-env.sh
@@ -17,6 +17,9 @@ export MESOS_NATIVE_LIBRARY=/usr/local/lib/libmesos.so
 # and have the master's SPARK_MEM variable get passed to the workers.
 export SPARK_MEM={{default_spark_mem}}
 
+# Use the public hostname of this EC2 machine for web UIs
+export SPARK_PUBLIC_DNS=`wget -q -O - http://instance-data.ec2.internal/latest/meta-data/public-hostname`
+
 # Set JVM options and Spark Java properties
 SPARK_JAVA_OPTS+=" -Dspark.local.dir={{spark_local_dirs}}"
 export SPARK_JAVA_OPTS


### PR DESCRIPTION
This will help in two ways:
- Scripts like bin/start-all.sh will always see it instead of relying on
  heuristics (e.g. does the hostname begin with ec2)
- User applications run from the command line will also see it, and will
  report correct application URLs to the cluster scheduler
