### PR TITLE
Use 'return' instead of 'exit in init & setup scripts (SPARK-919)

### DIFF
--- a/ephemeral-hdfs/init.sh
+++ b/ephemeral-hdfs/init.sh
@@ -4,7 +4,7 @@ pushd /root
 
 if [ -d "ephemeral-hdfs" ]; then
   echo "Ephemeral HDFS seems to be installed. Exiting."
-  exit 0
+  return 0
 fi
 
 case "$HADOOP_MAJOR_VERSION" in
@@ -30,7 +30,7 @@ case "$HADOOP_MAJOR_VERSION" in
 
   *)
      echo "ERROR: Unknown Hadoop version"
-     exit -1
+     return -1
 esac
 cp /root/hadoop-native/* ephemeral-hdfs/lib/native/
 /root/spark-ec2/copy-dir /root/ephemeral-hdfs

--- a/mapreduce/init.sh
+++ b/mapreduce/init.sh
@@ -14,7 +14,7 @@ case "$HADOOP_MAJOR_VERSION" in
 
   *)
      echo "ERROR: Unknown Hadoop version"
-     exit -1
+     return -1
 esac
 /root/spark-ec2/copy-dir /root/mapreduce
 popd

--- a/persistent-hdfs/init.sh
+++ b/persistent-hdfs/init.sh
@@ -4,7 +4,7 @@ pushd /root
 
 if [ -d "persistent-hdfs" ]; then
   echo "Persistent HDFS seems to be installed. Exiting."
-  exit 0
+  return 0
 fi
 
 case "$HADOOP_MAJOR_VERSION" in
@@ -29,7 +29,7 @@ case "$HADOOP_MAJOR_VERSION" in
 
   *)
      echo "ERROR: Unknown Hadoop version"
-     exit -1
+     return -1
 esac
 cp /root/hadoop-native/* /root/persistent-hdfs/lib/native/
 /root/spark-ec2/copy-dir /root/persistent-hdfs

--- a/setup.sh
+++ b/setup.sh
@@ -110,6 +110,7 @@ for module in $MODULES; do
   if [[ -e $module/init.sh ]]; then
     source $module/init.sh
   fi
+  cd /root/spark-ec2  # guard against init.sh changing the cwd
 done
 
 # Deploy templates
@@ -127,4 +128,5 @@ for module in $MODULES; do
   echo "Setting up $module"
   source ./$module/setup.sh
   sleep 1
+  cd /root/spark-ec2  # guard against setup.sh changing the cwd
 done

--- a/shark/init.sh
+++ b/shark/init.sh
@@ -4,7 +4,7 @@ pushd /root
 
 if [ -d "shark" ]; then
   echo "Shark seems to be installed. Exiting."
-  exit 0
+  return 0
 fi
 
 # Github tag:
@@ -32,7 +32,7 @@ else
       ;;
     *)
       echo "ERROR: Unknown Shark version"
-      exit -1
+      return -1
   esac
 
   echo "Unpacking Shark"

--- a/spark/init.sh
+++ b/spark/init.sh
@@ -4,7 +4,7 @@ pushd /root
 
 if [ -d "spark" ]; then
   echo "Spark seems to be installed. Exiting."
-  exit 0
+  return 0
 fi
 
 # Github tag:
@@ -41,7 +41,7 @@ else
       ;;    
     *)
       echo "ERROR: Unknown Spark version"
-      exit -1
+      return -1
   esac
 
   echo "Unpacking Spark"


### PR DESCRIPTION
<del>This commit addresses [SPARK-919](https://spark-project.atlassian.net/browse/SPARK-919), an issue where the `launch --resume` option could sometimes fail due to the top-level setup script exiting if the Spark module was already installed; the problem was that the `exit` command in the Spark `init.sh` script was being executed in the top-level setup script's shell.

<del>@pwendell @shivaram Was there a reason why this originally used `source` to run these scripts?  If we still need to use `source`, then we should find another way to implement defensive exits (instead of just calling `exit`: 1ac895e15c7e43f5de00123196c721c2723c9952).</del>


Update: I used `return` instead of `exit`, instead of getting rid of `source`.
