### PR TITLE
Set SPARK_PUBLIC_DNS in spark-env.sh (to address SPARK-833)

### DIFF
--- a/templates/root/spark/conf/spark-env.sh
+++ b/templates/root/spark/conf/spark-env.sh
@@ -25,3 +25,6 @@ export SPARK_LIBRARY_PATH="/root/ephemeral-hdfs/lib/native/"
 export SPARK_MASTER_IP={{active_master}}
 export MASTER=`cat /root/spark-ec2/cluster-url`
 export SPARK_CLASSPATH=$SPARK_CLASSPATH":/root/ephemeral-hdfs/conf"
+
+# Bind Spark's web UIs to this machine's public EC2 hostname:
+export SPARK_PUBLIC_DNS=`wget -q -O - http://instance-data.ec2.internal/latest/meta-data/public-hostname`


### PR DESCRIPTION
This is intended to address [SPARK-833](https://spark-project.atlassian.net/browse/SPARK-833), an issue where Spark web UIs might be bound to non-public addresses when running on EC2.  We had previously solved this problem for the Master and Worker UIs, but `SPARK_PUBLIC_DNS` needs to be set in the driver's environment in order for its application web UI to bind to the correct public address.
