### PR TITLE
Remove cloudfront URL's.

### DIFF
--- a/ephemeral-hdfs/init.sh
+++ b/ephemeral-hdfs/init.sh
@@ -9,7 +9,7 @@ fi
 
 case "$HADOOP_MAJOR_VERSION" in
   1)
-    wget http://d3kbcqa49mib13.cloudfront.net/hadoop-1.0.4.tar.gz
+    wget http://s3.amazonaws.com/spark-related-packages/hadoop-1.0.4.tar.gz
     echo "Unpacking Hadoop"
     tar xvzf hadoop-1.0.4.tar.gz > /tmp/spark-ec2_hadoop.log
     rm hadoop-*.tar.gz
@@ -17,7 +17,7 @@ case "$HADOOP_MAJOR_VERSION" in
     sed -i 's/-jvm server/-server/g' /root/ephemeral-hdfs/bin/hadoop
     ;;
   2) 
-    wget http://d3kbcqa49mib13.cloudfront.net/hadoop-2.0.0-cdh4.2.0.tar.gz  
+    wget http://s3.amazonaws.com/spark-related-packages/hadoop-2.0.0-cdh4.2.0.tar.gz  
     echo "Unpacking Hadoop"
     tar xvzf hadoop-*.tar.gz > /tmp/spark-ec2_hadoop.log
     rm hadoop-*.tar.gz

--- a/mapreduce/init.sh
+++ b/mapreduce/init.sh
@@ -6,7 +6,7 @@ case "$HADOOP_MAJOR_VERSION" in
     echo "Nothing to initialize for MapReduce in Hadoop 1"
     ;;
   2) 
-    wget http://d3kbcqa49mib13.cloudfront.net/mr1-2.0.0-mr1-cdh4.2.0.tar.gz 
+    wget http://s3.amazonaws.com/spark-related-packages/mr1-2.0.0-mr1-cdh4.2.0.tar.gz 
     tar -xvzf mr1-*.tar.gz > /tmp/spark-ec2_mapreduce.log
     rm mr1-*.tar.gz
     mv hadoop-2.0.0-mr1-cdh4.2.0/ mapreduce/

--- a/persistent-hdfs/init.sh
+++ b/persistent-hdfs/init.sh
@@ -9,14 +9,14 @@ fi
 
 case "$HADOOP_MAJOR_VERSION" in
   1)
-    wget http://d3kbcqa49mib13.cloudfront.net/hadoop-1.0.4.tar.gz
+    wget http://s3.amazonaws.com/spark-related-packages/hadoop-1.0.4.tar.gz
     echo "Unpacking Hadoop"
     tar xvzf hadoop-1.0.4.tar.gz > /tmp/spark-ec2_hadoop.log
     rm hadoop-*.tar.gz
     mv hadoop-1.0.4/ persistent-hdfs/
     ;;
   2)
-    wget http://d3kbcqa49mib13.cloudfront.net/hadoop-2.0.0-cdh4.2.0.tar.gz
+    wget http://s3.amazonaws.com/spark-related-packages/hadoop-2.0.0-cdh4.2.0.tar.gz
     echo "Unpacking Hadoop"
     tar xvzf hadoop-*.tar.gz > /tmp/spark-ec2_hadoop.log
     rm hadoop-*.tar.gz

--- a/shark/init.sh
+++ b/shark/init.sh
@@ -17,24 +17,24 @@ else
   case "$SHARK_VERSION" in
     0.7.0)
       if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://d3kbcqa49mib13.cloudfront.net/shark-0.7.0-hadoop1-bin.tgz
+        wget http://s3.amazonaws.com/spark-related-packages/shark-0.7.0-hadoop1-bin.tgz
       else
-        wget http://d3kbcqa49mib13.cloudfront.net/shark-0.7.0-hadoop2-bin.tgz
+        wget http://s3.amazonaws.com/spark-related-packages/shark-0.7.0-hadoop2-bin.tgz
       fi
       ;;    
     0.7.1)
       if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://d3kbcqa49mib13.cloudfront.net/shark-0.7.1-hadoop1-bin.tgz
+        wget http://s3.amazonaws.com/spark-related-packages/shark-0.7.1-hadoop1-bin.tgz
       else
-        wget http://d3kbcqa49mib13.cloudfront.net/shark-0.7.1-hadoop2-bin.tgz
+        wget http://s3.amazonaws.com/spark-related-packages/shark-0.7.1-hadoop2-bin.tgz
       fi
       ;;    
     0.8.0)
       # NOTE - this is a SNAPSHOT version of Shark for now.
       if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://d3kbcqa49mib13.cloudfront.net/shark-0.8.0-bin-hadoop1-ec2.tgz
+        wget http://s3.amazonaws.com/spark-related-packages/shark-0.8.0-bin-hadoop1-ec2.tgz
       else
-        wget http://d3kbcqa49mib13.cloudfront.net/shark-0.8.0-bin-cdh4-ec2.tgz
+        wget http://s3.amazonaws.com/spark-related-packages/shark-0.8.0-bin-cdh4-ec2.tgz
       fi
       ;;
     *)

--- a/spark/init.sh
+++ b/spark/init.sh
@@ -27,23 +27,23 @@ else
   case "$SPARK_VERSION" in
     0.7.3)
       if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://d3kbcqa49mib13.cloudfront.net/spark-0.7.3-prebuilt-hadoop1.tgz
+        wget http://s3.amazonaws.com/spark-related-packages/spark-0.7.3-prebuilt-hadoop1.tgz
       else
-        wget http://d3kbcqa49mib13.cloudfront.net/spark-0.7.3-prebuilt-cdh4.tgz
+        wget http://s3.amazonaws.com/spark-related-packages/spark-0.7.3-prebuilt-cdh4.tgz
       fi
       ;;    
     0.8.0)
       if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://d3kbcqa49mib13.cloudfront.net/spark-0.8.0-incubating-bin-hadoop1.tgz
+        wget http://s3.amazonaws.com/spark-related-packages/spark-0.8.0-incubating-bin-hadoop1.tgz
       else
-        wget http://d3kbcqa49mib13.cloudfront.net/spark-0.8.0-incubating-bin-cdh4.tgz
+        wget http://s3.amazonaws.com/spark-related-packages/spark-0.8.0-incubating-bin-cdh4.tgz
       fi
       ;;    
     0.8.1)
       if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://d3kbcqa49mib13.cloudfront.net/spark-0.8.1-incubating-bin-hadoop1.tgz
+        wget http://s3.amazonaws.com/spark-related-packages/spark-0.8.1-incubating-bin-hadoop1.tgz
       else
-        wget http://d3kbcqa49mib13.cloudfront.net/spark-0.8.1-incubating-bin-cdh4.tgz
+        wget http://s3.amazonaws.com/spark-related-packages/spark-0.8.1-incubating-bin-cdh4.tgz
       fi
       ;;    
     *)


### PR DESCRIPTION
I've consistently found that using CloudFront on top of the raw S3 bucket
has _worse_ performance than just downloading from S3 directly. This might
be because we tend to hit cold CloudFront caches since there are not
e.g. thousands of downloads of this per day. I've elected to revert
using CloudFront for now and we can switch it back on if we want
it.
