### PR TITLE
Use the public hostname for web UI

### DIFF
--- a/templates/root/spark/conf/spark-env.sh
+++ b/templates/root/spark/conf/spark-env.sh
@@ -20,6 +20,9 @@ export SPARK_MEM={{default_spark_mem}}
 # Set JVM options and Spark Java properties
 SPARK_JAVA_OPTS+=" -Dspark.local.dir={{spark_local_dirs}}"
 export SPARK_JAVA_OPTS
+ 
+# Use the public hostname of this EC2 machine for web UIs.
+export SPARK_PUBLIC_DNS=`wget -q -O - http://169.254.169.254/latest/meta-data/public-hostname`
 
 export SPARK_MASTER_IP={{active_master}}
 


### PR DESCRIPTION
This fixes an annoying problem where the links to the application detail UI on the master's UI don't work.  The added lines were copied from a different spark-ec2 branch (the v2 branch) where this is setup correctly.
