### PR TITLE
Support for Spark 1.0 configurations. 

### DIFF
--- a/templates/root/spark/conf/spark-defaults.conf
+++ b/templates/root/spark/conf/spark-defaults.conf
@@ -1,0 +1,3 @@
+spark.executor.memory	{{default_spark_mem}}
+spark.executor.extraLibraryPath	/root/ephemeral-hdfs/lib/native/
+spark.executor.extraClassPath	/root/ephemeral-hdfs/conf

--- a/templates/root/spark/conf/spark-env.sh
+++ b/templates/root/spark/conf/spark-env.sh
@@ -1,35 +1,18 @@
 #!/usr/bin/env bash
 
-# Set Spark environment variables for your site in this file. Some useful
-# variables to set are:
-# - MESOS_NATIVE_LIBRARY, to point to your Mesos native library (libmesos.so)
-# - SCALA_HOME, to point to your Scala installation
-# - SPARK_CLASSPATH, to add elements to Spark's classpath
-# - SPARK_JAVA_OPTS, to add JVM options
-# - SPARK_MEM, to change the amount of memory used per node (this should
-#   be in the same format as the JVM's -Xmx option, e.g. 300m or 1g).
-# - SPARK_LIBRARY_PATH, to add extra search paths for native libraries.
+export SPARK_LOCAL_DIR="{{spark_local_dirs}}"
 
-export SCALA_HOME="/root/scala"
-
-# Set Spark's memory per machine; note that you can also comment this out
-# and have the master's SPARK_MEM variable get passed to the workers.
-export SPARK_MEM={{default_spark_mem}}
-
-# Set JVM options and Spark Java properties
-SPARK_JAVA_OPTS+=" -Dspark.local.dir={{spark_local_dirs}}"
-export SPARK_JAVA_OPTS
-
+# Standalone cluster options
 export SPARK_MASTER_OPTS="{{spark_master_opts}}"
-
-export HADOOP_HOME="/root/ephemeral-hdfs"
-export SPARK_LIBRARY_PATH="/root/ephemeral-hdfs/lib/native/"
-export SPARK_MASTER_IP={{active_master}}
-export MASTER=`cat /root/spark-ec2/cluster-url`
-export SPARK_CLASSPATH=$SPARK_CLASSPATH":/root/ephemeral-hdfs/conf"
-
 export SPARK_WORKER_INSTANCES={{spark_worker_instances}}
 export SPARK_WORKER_CORES={{spark_worker_cores}}
+
+export HADOOP_HOME="/root/ephemeral-hdfs"
+export SPARK_MASTER_IP={{active_master}}
+export MASTER=`cat /root/spark-ec2/cluster-url`
+
+export SPARK_SUBMIT_LIBRARY_PATH="/root/ephemeral-hdfs/lib/native/"
+export SPARK_SUBMIT_CLASSPATH=$SPARK_CLASSPATH":/root/ephemeral-hdfs/conf"
 
 # Bind Spark's web UIs to this machine's public EC2 hostname:
 export SPARK_PUBLIC_DNS=`wget -q -O - http://169.254.169.254/latest/meta-data/public-hostname`


### PR DESCRIPTION
To avoid deprecation warnings, we should use the new configs present in Spark 1.0.
