### PR TITLE
Support for r3 instance types.

### DIFF
--- a/setup-slave.sh
+++ b/setup-slave.sh
@@ -14,26 +14,26 @@ HOSTNAME=$PRIVATE_DNS  # Fix the bash built-in hostname variable too
 
 echo "Setting up slave on `hostname`..."
 
-# Work around for R3 instances without pre-formatted disks
-instance_type=$(curl http://169.254.169.254/latest/meta-data/instance-type 2> /dev/null)
-if [[ $instance_type == r3* ]]; then
-  EXT3_MOUNT_OPTS="defaults,noatime,nodiratime"
-  rm -rf /mnt*
-
-  mkdir /mnt
-  mkfs.ext3 -E lazy_itable_init=0,lazy_journal_init=0 /dev/sdb
-  mount -o $EXT3_MOUNT_OPTS /dev/sdb /mnt
-
-  if [[ $instance_type == "r3.8xlarge" ]]; then
-    mkdir /mnt2
-    mkfs.ext3 -E lazy_itable_init=0,lazy_journal_init=0 /dev/sdc
-    mount -o $EXT3_MOUNT_OPTS /dev/sdb /mnt2
-  fi
-fi
-
 # Mount options to use for ext3 and xfs disks (the ephemeral disks
 # are ext3, but we use xfs for EBS volumes to format them faster)
 XFS_MOUNT_OPTS="defaults,noatime,nodiratime,allocsize=8m"
+
+# Work around for R3 instances without pre-formatted ext3 disks
+instance_type=$(curl http://169.254.169.254/latest/meta-data/instance-type 2> /dev/null)
+if [[ $instance_type == r3* ]]; then
+  yum install -y xfsprogs
+
+  rm -rf /mnt*
+  mkdir /mnt
+  mkfs.xfs /dev/sdb
+  mount -o $XFS_MOUNT_OPTS /dev/sdb /mnt
+
+  if [[ $instance_type == "r3.8xlarge" ]]; then
+    mkdir /mnt2
+    mkfs.xfs /dev/sdc
+    mount -o $XFS_MOUNT_OPTS /dev/sdb /mnt2
+  fi
+fi
 
 # Format and mount EBS volume (/dev/sdv) as /vol if the device exists
 if [[ -e /dev/sdv ]]; then

--- a/setup-slave.sh
+++ b/setup-slave.sh
@@ -31,7 +31,7 @@ if [[ $instance_type == r3* ]]; then
   if [[ $instance_type == "r3.8xlarge" ]]; then
     mkdir /mnt2
     mkfs.xfs /dev/sdc
-    mount -o $XFS_MOUNT_OPTS /dev/sdb /mnt2
+    mount -o $XFS_MOUNT_OPTS /dev/sdc /mnt2
   fi
 fi
 


### PR DESCRIPTION
Amazon's new r3 instances come without EXT3-formatted drives. This patch
adds a workaround that detects this situation and formats the drives
as ext3.

Hopefully this will be subsumed later if anyone wants to pick up
SPARK-1079.
