### PR TITLE
Replace xfs with ext4 for r3 SSD instances

### DIFF
--- a/setup-slave.sh
+++ b/setup-slave.sh
@@ -22,12 +22,14 @@ if [[ $instance_type == r3* ]]; then
   EXT4_MOUNT_OPTS="defaults,noatime,nodiratime"
   rm -rf /mnt*
   mkdir /mnt
+  # To turn TRIM support on, uncomment the following line.
   #echo '/dev/sdb /mnt  ext4  defaults,noatime,nodiratime,discard 0 0' >> /etc/fstab
   mkfs.ext4 -E lazy_itable_init=0,lazy_journal_init=0 /dev/sdb
   mount -o $EXT4_MOUNT_OPTS /dev/sdb /mnt
 
   if [[ $instance_type == "r3.8xlarge" ]]; then
     mkdir /mnt2
+    # To turn TRIM support on, uncomment the following line.
     #echo '/dev/sdc /mnt2  ext4  defaults,noatime,nodiratime,discard 0 0' >> /etc/fstab
     mkfs.ext4 -E lazy_itable_init=0,lazy_journal_init=0 /dev/sdc
     mount -o $EXT4_MOUNT_OPTS /dev/sdc /mnt2


### PR DESCRIPTION
In my experience xfs had a lot of problems during shuffle heavy workloads. All the problems I observed went away when I replaced the file system with ext4. We might be able to tune xfs to be better; however, ext4 just provides better out of the box behavior here without us having to dig deeper into file system tuning. 
