### PR TITLE
Add S3 configuration

### DIFF
--- a/deploy_templates.py
+++ b/deploy_templates.py
@@ -69,6 +69,8 @@ template_vars = {
   "hadoop_major_version": os.getenv("HADOOP_MAJOR_VERSION"),
   "java_home": os.getenv("JAVA_HOME"),
   "default_tachyon_mem": "%dMB" % tachyon_mb,
+  "aws_access_key_id": os.getenv("AWS_ACCESS_KEY_ID"),
+  "aws_secret_access_key": os.getenv("AWS_SECRET_ACCESS_KEY"),
 }
 
 template_dir="/root/spark-ec2/templates"

--- a/templates/root/ephemeral-hdfs/conf/core-site.xml
+++ b/templates/root/ephemeral-hdfs/conf/core-site.xml
@@ -45,4 +45,14 @@
     <value>tachyon.hadoop.TFS</value>
   </property>
 
+  <property>
+    <name>fs.s3n.awsAccessKeyId</name>
+    <value>{{aws_access_key_id}}</value>
+  </property>
+
+  <property>
+    <name>fs.s3n.awsSecretAccessKey</name>
+    <value>{{aws_secret_access_key}}</value>
+  </property>
+
 </configuration>


### PR DESCRIPTION
When deploying to AWS, its helpful to add the S3 configuration, so that Spark can access S3 transparently. If the access keys are not available in the environment, the configuration will be empty.
