### PR TITLE
check whether file/directory exists in copy-dir

### DIFF
--- a/copy-dir.sh
+++ b/copy-dir.sh
@@ -28,6 +28,11 @@ if [[ "$#" != "1" ]] ; then
   usage
 fi
 
+if [[ ! -e "$1" ]] ; then
+  echo "File or directory $1 doesn't exist!"
+  exit 1
+fi
+
 DIR=`readlink -f "$1"`
 DIR=`echo "$DIR"|sed 's@/$@@'`
 DEST=`dirname "$DIR"`


### PR DESCRIPTION
If a user run copy-dir with a nonexistent path and "--delete", the worst outcome is that rsync will remove everything on the worker node including ssh configurations.
