### PR TITLE
Disable Transparent Huge Pages.

### DIFF
--- a/setup-slave.sh
+++ b/setup-slave.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Disable Transparent Huge Pages (THP)
+# THP can result in system thrashing (high sys usage) due to frequent defrags of memory.
+# Most systems recommends turning THP off.
+echo never > /sys/kernel/mm/transparent_hugepage/enabled
+
 # Make sure we are in the spark-ec2 directory
 cd /root/spark-ec2
 

--- a/setup-slave.sh
+++ b/setup-slave.sh
@@ -3,7 +3,9 @@
 # Disable Transparent Huge Pages (THP)
 # THP can result in system thrashing (high sys usage) due to frequent defrags of memory.
 # Most systems recommends turning THP off.
-echo never > /sys/kernel/mm/transparent_hugepage/enabled
+if [[ -e /sys/kernel/mm/transparent_hugepage/enabled ]]; then
+  echo never > /sys/kernel/mm/transparent_hugepage/enabled
+fi
 
 # Make sure we are in the spark-ec2 directory
 cd /root/spark-ec2


### PR DESCRIPTION
See examples online from various system vendors recommending turning THP off:
http://blog.couchbase.com/often-overlooked-linux-os-tweaks
https://my.vertica.com/docs/7.1.x/HTML/Content/Authoring/InstallationGuide/BeforeYouInstall/transparenthugepages.htm
http://www.cloudera.com/content/cloudera-content/cloudera-docs/CDH4/4.2.2/CDH4-Installation-Guide/cdh4ig_topic_11_6.html

Information on THP: 
http://www.slideshare.net/raghusiddarth/transparent-hugepages-in-rhel-6

dstat/perf trace when the problem happens:
https://gist.github.com/rxin/eac982fe23396d5efddf
