### PR TITLE
SCALA_HOME is no longer required by anything.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -34,11 +34,6 @@ if [[ "x$JAVA_HOME" == "x" ]] ; then
     exit 1
 fi
 
-if [[ "x$SCALA_HOME" == "x" ]] ; then
-    echo "Expected SCALA_HOME to be set in .bash_profile!"
-    exit 1
-fi
-
 if [[ `tty` == "not a tty" ]] ; then
     echo "Expecting a tty or pty! (use the ssh -t option)."
     exit 1


### PR DESCRIPTION
We shouldn't exist if it is not defined. I ran into this when trying to create a new AMI.
