### PR TITLE
Fixing httpd configuration file (possibly related to SPARK-2649)

### DIFF
--- a/ganglia/init.sh
+++ b/ganglia/init.sh
@@ -4,10 +4,6 @@
 rm -rf /var/lib/ganglia/rrds/*
 rm -rf /mnt/ganglia/rrds/*
 
-# Symlink /var/lib/ganglia/rrds to /mnt/ganglia/rrds
-rmdir /var/lib/ganglia/rrds
-ln -s /mnt/ganglia/rrds /var/lib/ganglia/rrds
-
 # Make sure rrd storage directory has right permissions
 mkdir -p /mnt/ganglia/rrds
 chown -R nobody:nobody /mnt/ganglia/rrds
@@ -24,3 +20,7 @@ for node in $SLAVES $OTHER_MASTERS; do
   ssh -t -t $SSH_OPTS root@$node "if ! rpm --quiet -q $GANGLIA_PACKAGES; then yum install -q -y $GANGLIA_PACKAGES; fi" & sleep 0.3
 done
 wait
+
+# Post-package installation : Symlink /var/lib/ganglia/rrds to /mnt/ganglia/rrds
+rmdir /var/lib/ganglia/rrds
+ln -s /mnt/ganglia/rrds /var/lib/ganglia/rrds

--- a/templates/etc/httpd/conf/httpd.conf
+++ b/templates/etc/httpd/conf/httpd.conf
@@ -424,17 +424,6 @@ AccessFileName .htaccess
 TypesConfig /etc/mime.types
 
 #
-# DefaultType is the default MIME type the server will use for a document
-# if it cannot otherwise determine one, such as from filename extensions.
-# If your server contains mostly text or HTML documents, "text/plain" is
-# a good value.  If most of your content is binary, such as applications
-# or images, you may want to use "application/octet-stream" instead to
-# keep browsers from trying to display binary files as though they are
-# text.
-#
-DefaultType text/plain
-
-#
 # The mod_mime_magic module allows the server to use various hints from the
 # contents of the file itself to determine its type.  The MIMEMagicFile
 # directive tells the module where the hint definitions are located.
@@ -538,16 +527,6 @@ ServerSignature On
 # Aliases: Add here as many aliases as you need (with no limit). The format is 
 # Alias fakename realname
 #
-# Note that if you include a trailing / on fakename then the server will
-# require it to be present in the URL.  So "/icons" isn't aliased in this
-# example, only "/icons/".  If the fakename is slash-terminated, then the 
-# realname must also be slash terminated, and if the fakename omits the 
-# trailing slash, the realname must also omit it.
-#
-# We include the /icons/ alias for FancyIndexed directory listings.  If you
-# do not use FancyIndexing, you may comment this out.
-#
-Alias /icons/ "/var/www/icons/"
 
 <Directory "/var/www/icons">
     Options Indexes MultiViews FollowSymLinks
@@ -592,80 +571,6 @@ ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
 # Example:
 # Redirect permanent /foo http://www.example.com/bar
 
-#
-# Directives controlling the display of server-generated directory listings.
-#
-
-#
-# IndexOptions: Controls the appearance of server-generated directory
-# listings.
-#
-IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
-
-#
-# AddIcon* directives tell the server which icon to show for different
-# files or filename extensions.  These are only displayed for
-# FancyIndexed directories.
-#
-AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
-
-AddIconByType (TXT,/icons/text.gif) text/*
-AddIconByType (IMG,/icons/image2.gif) image/*
-AddIconByType (SND,/icons/sound2.gif) audio/*
-AddIconByType (VID,/icons/movie.gif) video/*
-
-AddIcon /icons/binary.gif .bin .exe
-AddIcon /icons/binhex.gif .hqx
-AddIcon /icons/tar.gif .tar
-AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
-AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
-AddIcon /icons/a.gif .ps .ai .eps
-AddIcon /icons/layout.gif .html .shtml .htm .pdf
-AddIcon /icons/text.gif .txt
-AddIcon /icons/c.gif .c
-AddIcon /icons/p.gif .pl .py
-AddIcon /icons/f.gif .for
-AddIcon /icons/dvi.gif .dvi
-AddIcon /icons/uuencoded.gif .uu
-AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
-AddIcon /icons/tex.gif .tex
-AddIcon /icons/bomb.gif core
-
-AddIcon /icons/back.gif ..
-AddIcon /icons/hand.right.gif README
-AddIcon /icons/folder.gif ^^DIRECTORY^^
-AddIcon /icons/blank.gif ^^BLANKICON^^
-
-#
-# DefaultIcon is which icon to show for files which do not have an icon
-# explicitly set.
-#
-DefaultIcon /icons/unknown.gif
-
-#
-# AddDescription allows you to place a short description after a file in
-# server-generated indexes.  These are only displayed for FancyIndexed
-# directories.
-# Format: AddDescription "description" filename
-#
-#AddDescription "GZIP compressed document" .gz
-#AddDescription "tar archive" .tar
-#AddDescription "GZIP compressed tar archive" .tgz
-
-#
-# ReadmeName is the name of the README file the server will look for by
-# default, and append to directory listings.
-#
-# HeaderName is the name of a file which should be prepended to
-# directory indexes. 
-ReadmeName README.html
-HeaderName HEADER.html
-
-#
-# IndexIgnore is a set of filenames which directory indexing should ignore
-# and not include in the listing.  Shell-style wildcarding is permitted.
-#
-IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
 
 #
 # DefaultLanguage and AddLanguage allows you to specify the language of 

--- a/templates/etc/httpd/conf/httpd.conf
+++ b/templates/etc/httpd/conf/httpd.conf
@@ -150,18 +150,14 @@ Listen 5080
 LoadModule auth_basic_module modules/mod_auth_basic.so
 LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule authn_file_module modules/mod_authn_file.so
-LoadModule authn_alias_module modules/mod_authn_alias.so
 LoadModule authn_anon_module modules/mod_authn_anon.so
+LoadModule authz_core_module modules/mod_authz_core.so
 LoadModule authn_dbm_module modules/mod_authn_dbm.so
-LoadModule authn_default_module modules/mod_authn_default.so
 LoadModule authz_host_module modules/mod_authz_host.so
 LoadModule authz_user_module modules/mod_authz_user.so
 LoadModule authz_owner_module modules/mod_authz_owner.so
 LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
 LoadModule authz_dbm_module modules/mod_authz_dbm.so
-LoadModule authz_default_module modules/mod_authz_default.so
-LoadModule ldap_module modules/mod_ldap.so
-LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
 LoadModule include_module modules/mod_include.so
 LoadModule log_config_module modules/mod_log_config.so
 LoadModule logio_module modules/mod_logio.so
@@ -189,16 +185,18 @@ LoadModule alias_module modules/mod_alias.so
 LoadModule substitute_module modules/mod_substitute.so
 LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule proxy_module modules/mod_proxy.so
-LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
 LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
 LoadModule proxy_http_module modules/mod_proxy_http.so
 LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
 LoadModule proxy_connect_module modules/mod_proxy_connect.so
 LoadModule cache_module modules/mod_cache.so
 LoadModule suexec_module modules/mod_suexec.so
-LoadModule disk_cache_module modules/mod_disk_cache.so
 LoadModule cgi_module modules/mod_cgi.so
 LoadModule version_module modules/mod_version.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
+LoadModule php5_module modules/libphp-5.5.so
 
 #
 # The following modules are not loaded by default:


### PR DESCRIPTION
Hello
The httpd daemon hosting ganglia cannot launch on ami spark.ami.hvm.v14 (ami-2ae0165d), running on a m3.large instance 
This commit removes / adds some apache modules to allow httpd to start and serve the ganglia php scripts
Any feedback welcome
Fred
