### PR TITLE
Support Spark 1.1.1

### DIFF
--- a/spark/init.sh
+++ b/spark/init.sh
@@ -95,6 +95,13 @@ else
         wget http://s3.amazonaws.com/spark-related-packages/spark-1.1.0-bin-cdh4.tgz
       fi
       ;;
+    1.1.1)
+      if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
+        wget http://s3.amazonaws.com/spark-related-packages/spark-1.1.1-bin-hadoop1.tgz
+      else
+        wget http://s3.amazonaws.com/spark-related-packages/spark-1.1.1-bin-cdh4.tgz
+      fi
+      ;;
     *)
       echo "ERROR: Unknown Spark version"
       return


### PR DESCRIPTION
@shivaram can you merge this, Spark 1.1 is actually still using the v3 branch: https://github.com/apache/spark/blob/branch-1.1/ec2/spark_ec2.py#L523
