### PR TITLE
[SPARK-4948] Use pssh.

### DIFF
--- a/setup-slave.sh
+++ b/setup-slave.sh
@@ -8,7 +8,7 @@ if [[ -e /sys/kernel/mm/transparent_hugepage/enabled ]]; then
 fi
 
 # Make sure we are in the spark-ec2 directory
-cd /root/spark-ec2
+pushd /root/spark-ec2
 
 source ec2-variables.sh
 
@@ -114,3 +114,5 @@ cat /root/spark-ec2/github.hostkey >> /root/.ssh/known_hosts
 echo '#!/bin/bash' > /usr/bin/realpath
 echo 'readlink -e "$@"' >> /usr/bin/realpath
 chmod a+x /usr/bin/realpath
+
+popd

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 yum install -y pssh
 
 # Make sure we are in the spark-ec2 directory
-cd /root/spark-ec2
+pushd /root/spark-ec2
 
 # Load the environment variables specific to this AMI
 source /root/.bash_profile
@@ -107,3 +107,5 @@ for module in $MODULES; do
   sleep 0.1
   cd /root/spark-ec2  # guard against setup.sh changing the cwd
 done
+
+popd

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-yum install -y pssh
+sudo yum install -y pssh
 
 # Make sure we are in the spark-ec2 directory
 pushd /root/spark-ec2

--- a/setup.sh
+++ b/setup.sh
@@ -12,11 +12,14 @@ source /root/.bash_profile
 source ec2-variables.sh
 
 function approve_ssh_keys () {
-  pssh --inline \
-      --host "localhost $(hostname) $MASTERS $SLAVES" \
-      --user root \
-      --extra-args "$SSH_OPTS" \
-      ":"
+  time {
+    pssh --inline \
+        --host "localhost $(hostname) $MASTERS $SLAVES" \
+        --user root \
+        --extra-args "$SSH_OPTS" \
+        ":"
+  }
+  echo " ✝ approve_ssh_keys"
 }
 
 # Set hostname based on EC2 private DNS name, so that it is set correctly
@@ -65,11 +68,14 @@ done
 wait
 
 echo "Running setup-slave on all cluster nodes to mount filesystems, etc..."
-pssh --inline \
-    --host "$MASTERS $SLAVES" \
-    --user root \
-    --extra-args "-t -t $SSH_OPTS" \
-    "spark-ec2/setup-slave.sh"
+time {
+  pssh --inline \
+      --host "$MASTERS $SLAVES" \
+      --user root \
+      --extra-args "-t -t $SSH_OPTS" \
+      "spark-ec2/setup-slave.sh"
+}
+echo " ✝ setup-slave"
 
 echo "SSH-ing to all cluster nodes to re-approve keys..."
 # We do this again because setup-slave.sh clears out .ssh/known_hosts.

--- a/setup.sh
+++ b/setup.sh
@@ -52,8 +52,8 @@ fi
 echo "Setting executable permissions on scripts..."
 find . -regex "^.+.\(sh\|py\)" | xargs chmod a+x
 
-echo "SSH-ing to all cluster nodes to approve keys..."
-approve_ssh_keys
+# echo "SSH-ing to all cluster nodes to approve keys..."
+# approve_ssh_keys
 
 echo "RSYNC'ing /root/spark-ec2 to other cluster nodes..."
 for node in $SLAVES $OTHER_MASTERS; do
@@ -71,9 +71,9 @@ pssh --inline \
     --extra-args "-t -t $SSH_OPTS" \
     "spark-ec2/setup-slave.sh"
 
-echo "SSH-ing to all cluster nodes to re-approve keys..."
+# echo "SSH-ing to all cluster nodes to re-approve keys..."
 # We do this again because setup-slave.sh clears out .ssh/known_hosts.
-approve_ssh_keys
+# approve_ssh_keys
 
 # Always include 'scala' module if it's not defined as a work around
 # for older versions of the scripts.

--- a/setup.sh
+++ b/setup.sh
@@ -12,14 +12,11 @@ source /root/.bash_profile
 source ec2-variables.sh
 
 function approve_ssh_keys () {
-  time {
-    pssh --inline \
-        --host "localhost $(hostname) $MASTERS $SLAVES" \
-        --user root \
-        --extra-args "$SSH_OPTS" \
-        ":"
-  }
-  echo " ✝ approve_ssh_keys"
+  pssh --inline \
+      --host "localhost $(hostname) $MASTERS $SLAVES" \
+      --user root \
+      --extra-args "$SSH_OPTS" \
+      ":"
 }
 
 # Set hostname based on EC2 private DNS name, so that it is set correctly
@@ -68,14 +65,11 @@ done
 wait
 
 echo "Running setup-slave on all cluster nodes to mount filesystems, etc..."
-time {
-  pssh --inline \
-      --host "$MASTERS $SLAVES" \
-      --user root \
-      --extra-args "-t -t $SSH_OPTS" \
-      "spark-ec2/setup-slave.sh"
-}
-echo " ✝ setup-slave"
+pssh --inline \
+    --host "$MASTERS $SLAVES" \
+    --user root \
+    --extra-args "-t -t $SSH_OPTS" \
+    "spark-ec2/setup-slave.sh"
 
 echo "SSH-ing to all cluster nodes to re-approve keys..."
 # We do this again because setup-slave.sh clears out .ssh/known_hosts.

--- a/setup.sh
+++ b/setup.sh
@@ -46,7 +46,7 @@ find . -regex "^.+.\(sh\|py\)" | xargs chmod a+x
 
 echo "SSH-ing to all cluster nodes to approve keys..."
 pssh --inline \
-    --host "localhost $MASTERS $SLAVES" \
+    --host "localhost $(hostname) $MASTERS $SLAVES" \
     --user root \
     --extra-args "$SSH_OPTS" \
     ":"

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+yum install -y pssh
+
 # Make sure we are in the spark-ec2 directory
 cd /root/spark-ec2
 
@@ -42,60 +44,29 @@ fi
 echo "Setting executable permissions on scripts..."
 find . -regex "^.+.\(sh\|py\)" | xargs chmod a+x
 
-echo "Running setup-slave on master to mount filesystems, etc..."
-source ./setup-slave.sh
-
-echo "SSH'ing to master machine(s) to approve key(s)..."
-for master in $MASTERS; do
-  echo $master
-  ssh $SSH_OPTS $master echo -n &
-  sleep 0.3
-done
-ssh $SSH_OPTS localhost echo -n &
-ssh $SSH_OPTS `hostname` echo -n &
-wait
-
-# Try to SSH to each cluster node to approve their key. Since some nodes may
-# be slow in starting, we retry failed slaves up to 3 times.
-TODO="$SLAVES $OTHER_MASTERS" # List of nodes to try (initially all)
-TRIES="0"                          # Number of times we've tried so far
-echo "SSH'ing to other cluster nodes to approve keys..."
-while [ "e$TODO" != "e" ] && [ $TRIES -lt 4 ] ; do
-  NEW_TODO=
-  for slave in $TODO; do
-    echo $slave
-    ssh $SSH_OPTS $slave echo -n
-    if [ $? != 0 ] ; then
-        NEW_TODO="$NEW_TODO $slave"
-    fi
-  done
-  TRIES=$[$TRIES + 1]
-  if [ "e$NEW_TODO" != "e" ] && [ $TRIES -lt 4 ] ; then
-      sleep 15
-      TODO="$NEW_TODO"
-      echo "Re-attempting SSH to cluster nodes to approve keys..."
-  else
-      break;
-  fi
-done
+echo "SSH-ing to all cluster nodes to approve keys..."
+pssh --inline \
+    --host "localhost $MASTERS $SLAVES" \
+    --user root \
+    --extra-args "$SSH_OPTS" \
+    ":"
 
 echo "RSYNC'ing /root/spark-ec2 to other cluster nodes..."
 for node in $SLAVES $OTHER_MASTERS; do
   echo $node
   rsync -e "ssh $SSH_OPTS" -az /root/spark-ec2 $node:/root &
   scp $SSH_OPTS ~/.ssh/id_rsa $node:.ssh &
-  sleep 0.3
+  sleep 0.1
 done
 wait
 
-# NOTE: We need to rsync spark-ec2 before we can run setup-slave.sh
-# on other cluster nodes
-echo "Running slave setup script on other cluster nodes..."
-for node in $SLAVES $OTHER_MASTERS; do
-  echo $node
-  ssh -t -t $SSH_OPTS root@$node "spark-ec2/setup-slave.sh" & sleep 0.3
-done
-wait
+echo "Running setup-slave on all cluster nodes to mount filesystems, etc..."
+pssh --inline \
+    --host "$MASTERS $SLAVES" \
+    --user root \
+    --extra-args "-t -t $SSH_OPTS" \
+    "spark-ec2/setup-slave.sh"
+
 
 # Always include 'scala' module if it's not defined as a work around
 # for older versions of the scripts.
@@ -126,6 +97,6 @@ chmod u+x /root/spark/conf/spark-env.sh
 for module in $MODULES; do
   echo "Setting up $module"
   source ./$module/setup.sh
-  sleep 1
+  sleep 0.1
   cd /root/spark-ec2  # guard against setup.sh changing the cwd
 done

--- a/setup.sh
+++ b/setup.sh
@@ -11,14 +11,6 @@ source /root/.bash_profile
 # Load the cluster variables set by the deploy script
 source ec2-variables.sh
 
-function approve_ssh_keys () {
-  pssh --inline \
-      --host "localhost $(hostname) $MASTERS $SLAVES" \
-      --user root \
-      --extra-args "$SSH_OPTS" \
-      ":"
-}
-
 # Set hostname based on EC2 private DNS name, so that it is set correctly
 # even if the instance is restarted with a different private DNS name
 PRIVATE_DNS=`wget -q -O - http://instance-data.ec2.internal/latest/meta-data/local-hostname`
@@ -52,9 +44,6 @@ fi
 echo "Setting executable permissions on scripts..."
 find . -regex "^.+.\(sh\|py\)" | xargs chmod a+x
 
-# echo "SSH-ing to all cluster nodes to approve keys..."
-# approve_ssh_keys
-
 echo "RSYNC'ing /root/spark-ec2 to other cluster nodes..."
 for node in $SLAVES $OTHER_MASTERS; do
   echo $node
@@ -70,10 +59,6 @@ pssh --inline \
     --user root \
     --extra-args "-t -t $SSH_OPTS" \
     "spark-ec2/setup-slave.sh"
-
-# echo "SSH-ing to all cluster nodes to re-approve keys..."
-# We do this again because setup-slave.sh clears out .ssh/known_hosts.
-# approve_ssh_keys
 
 # Always include 'scala' module if it's not defined as a work around
 # for older versions of the scripts.


### PR DESCRIPTION
- Replace some bash-isms with calls to `pssh` to neatly parallelize cluster operations.
- Remove unnecessary code to pre-approve SSH keys.
- Decrease questionably high sleep times.
