### PR TITLE
[SPARK-5125] Time major blocks of code in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-sudo yum install -y pssh
+sudo yum install -y -q pssh
+
+# usage: echo_time_diff name start_time end_time
+echo_time_diff () {
+  local format='%Hh %Mm %Ss'
+
+  local diff_secs="$(($3-$2))"
+  echo "[timing] $1: " "$(date -u -d@"$diff_secs" +"$format")"
+}
 
 # Make sure we are in the spark-ec2 directory
 pushd /root/spark-ec2 > /dev/null
@@ -45,6 +53,7 @@ echo "Setting executable permissions on scripts..."
 find . -regex "^.+.\(sh\|py\)" | xargs chmod a+x
 
 echo "RSYNC'ing /root/spark-ec2 to other cluster nodes..."
+rsync_start_time="$(date +'%s')"
 for node in $SLAVES $OTHER_MASTERS; do
   echo $node
   rsync -e "ssh $SSH_OPTS" -az /root/spark-ec2 $node:/root &
@@ -52,13 +61,18 @@ for node in $SLAVES $OTHER_MASTERS; do
   sleep 0.1
 done
 wait
+rsync_end_time="$(date +'%s')"
+echo_time_diff "rsync /root/spark-ec2" "$rsync_start_time" "$rsync_end_time"
 
 echo "Running setup-slave on all cluster nodes to mount filesystems, etc..."
+setup_slave_start_time="$(date +'%s')"
 pssh --inline \
     --host "$MASTERS $SLAVES" \
     --user root \
     --extra-args "-t -t $SSH_OPTS" \
     "spark-ec2/setup-slave.sh"
+setup_slave_end_time="$(date +'%s')"
+echo_time_diff "setup-slave" "$setup_slave_start_time" "$setup_slave_end_time"
 
 # Always include 'scala' module if it's not defined as a work around
 # for older versions of the scripts.
@@ -69,9 +83,12 @@ fi
 # Install / Init module
 for module in $MODULES; do
   echo "Initializing $module"
+  module_init_start_time="$(date +'%s')"
   if [[ -e $module/init.sh ]]; then
     source $module/init.sh
   fi
+  module_init_end_time="$(date +'%s')"
+  echo_time_diff "$module init" "$module_init_start_time" "$module_init_end_time"
   cd /root/spark-ec2  # guard against init.sh changing the cwd
 done
 
@@ -88,8 +105,11 @@ chmod u+x /root/spark/conf/spark-env.sh
 # Setup each module
 for module in $MODULES; do
   echo "Setting up $module"
+  module_setup_start_time="$(date +'%s')"
   source ./$module/setup.sh
   sleep 0.1
+  module_setup_end_time="$(date +'%s')"
+  echo_time_diff "$module setup" "$module_setup_start_time" "$module_setup_end_time"
   cd /root/spark-ec2  # guard against setup.sh changing the cwd
 done
 


### PR DESCRIPTION
To make it easy to record and compare the performance of invocations of `spark-ec2`, print out some minimal timing information from `setup.sh`.
