### PR TITLE
Add Spark 1.2.1 to init.sh

### DIFF
--- a/spark/init.sh
+++ b/spark/init.sh
@@ -109,6 +109,13 @@ else
         wget http://s3.amazonaws.com/spark-related-packages/spark-1.2.0-bin-cdh4.tgz
       fi
       ;;
+    1.2.1)
+      if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
+        wget http://s3.amazonaws.com/spark-related-packages/spark-1.2.1-bin-hadoop1.tgz
+      else
+        wget http://s3.amazonaws.com/spark-related-packages/spark-1.2.1-bin-cdh4.tgz
+      fi
+      ;;
     *)
       echo "ERROR: Unknown Spark version"
       return


### PR DESCRIPTION
Fix missed update of `init.sh` on Spark 1.2.1 release.
