### PR TITLE
Add Spark version 1.3.0

### DIFF
--- a/spark/init.sh
+++ b/spark/init.sh
@@ -116,6 +116,13 @@ else
         wget http://s3.amazonaws.com/spark-related-packages/spark-1.2.1-bin-cdh4.tgz
       fi
       ;;
+    1.3.0)
+      if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
+        wget http://s3.amazonaws.com/spark-related-packages/spark-1.3.0-bin-hadoop1.tgz
+      else
+        wget http://s3.amazonaws.com/spark-related-packages/spark-1.3.0-bin-cdh4.tgz
+      fi
+      ;;
     *)
       echo "ERROR: Unknown Spark version"
       return


### PR DESCRIPTION
Adding update of init.sh for Spark 1.3.0 release.

Successfully launched a Spark 1.3 cluster by pointing `spark-ec2` to this branch.
