### PR TITLE
Fix for starting httpd on r3.4xlarge

### DIFF
--- a/templates/etc/httpd/conf/httpd.conf
+++ b/templates/etc/httpd/conf/httpd.conf
@@ -196,7 +196,7 @@ LoadModule version_module modules/mod_version.so
 LoadModule unixd_module modules/mod_unixd.so
 LoadModule access_compat_module modules/mod_access_compat.so
 LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
-LoadModule php5_module modules/libphp-5.5.so
+LoadModule php5_module modules/libphp-5.6.so
 
 #
 # The following modules are not loaded by default:


### PR DESCRIPTION
The merge of #76 improved things in terms of starting Apache on r3.4xlarge instances, but I also had to add this patch to fix the PHP module version before `service httpd start` worked successfully.

I have not tested this on other instance types. (Apparently there's some differences between the HVM and non-HVM AMIs?)
