### PR TITLE
[SPARK-8327] Fixes issue with Ganglia not available

### DIFF
--- a/ganglia/init.sh
+++ b/ganglia/init.sh
@@ -8,6 +8,10 @@ rm -rf /mnt/ganglia/rrds/*
 mkdir -p /mnt/ganglia/rrds
 chown -R nobody:nobody /mnt/ganglia/rrds
 
+
+#Uninstall older version of ganglia if it was reinstalled in AMI
+ssh -t -t $SSH_OPTS root@$node "sudo yum remove -q -y httpd* php* ganglia ganglia-web ganglia-gmond ganglia-gmetad" & sleep 0.3
+
 # Install ganglia
 # TODO: Remove this once the AMI has ganglia by default
 

--- a/ganglia/init.sh
+++ b/ganglia/init.sh
@@ -11,7 +11,7 @@ chown -R nobody:nobody /mnt/ganglia/rrds
 # Install ganglia
 # TODO: Remove this once the AMI has ganglia by default
 
-GANGLIA_PACKAGES="httpd24-2.4 php56-common-5.6 ganglia-3.6 ganglia-web-3.5 ganglia-gmond-3.6 ganglia-gmetad-3.6"
+GANGLIA_PACKAGES="httpd24-2.4* php56-5.6* ganglia-3.6* ganglia-web-3.5* ganglia-gmond-3.6* ganglia-gmetad-3.6*"
 
 if ! rpm --quiet -q $GANGLIA_PACKAGES; then
   yum install -q -y $GANGLIA_PACKAGES;

--- a/ganglia/init.sh
+++ b/ganglia/init.sh
@@ -9,19 +9,18 @@ mkdir -p /mnt/ganglia/rrds
 chown -R nobody:nobody /mnt/ganglia/rrds
 
 
-#Uninstall older version of ganglia if it was reinstalled in AMI
-ssh -t -t $SSH_OPTS root@$node "sudo yum remove -q -y httpd* php* ganglia ganglia-web ganglia-gmond ganglia-gmetad" & sleep 0.3
-
 # Install ganglia
 # TODO: Remove this once the AMI has ganglia by default
 
 GANGLIA_PACKAGES="httpd24-2.4* php56-5.6* ganglia-3.6* ganglia-web-3.5* ganglia-gmond-3.6* ganglia-gmetad-3.6*"
 
-if ! rpm --quiet -q $GANGLIA_PACKAGES; then
-  yum install -q -y $GANGLIA_PACKAGES;
-fi
+#Uninstall older version of ganglia if it was reinstalled in AMI
+yum remove -q -y httpd* php* ganglia ganglia-web ganglia-gmond ganglia-gmetad & sleep 0.3
+yum install -q -y $GANGLIA_PACKAGES
+
 for node in $SLAVES $OTHER_MASTERS; do
-  ssh -t -t $SSH_OPTS root@$node "if ! rpm --quiet -q $GANGLIA_PACKAGES; then yum install -q -y $GANGLIA_PACKAGES; fi" & sleep 0.3
+  ssh -t -t $SSH_OPTS root@$node "yum remove -q -y httpd* php* ganglia ganglia-web ganglia-gmond ganglia-gmetad" & sleep 0.3
+  ssh -t -t $SSH_OPTS root@$node "yum install -q -y $GANGLIA_PACKAGES" & sleep 0.3
 done
 wait
 

--- a/ganglia/init.sh
+++ b/ganglia/init.sh
@@ -12,14 +12,15 @@ chown -R nobody:nobody /mnt/ganglia/rrds
 # Install ganglia
 # TODO: Remove this once the AMI has ganglia by default
 
+OLD_GANGLIA_PACKAGES="httpd* php* ganglia ganglia-web ganglia-gmond ganglia-gmetad"
 GANGLIA_PACKAGES="httpd24-2.4* php56-5.6* ganglia-3.6* ganglia-web-3.5* ganglia-gmond-3.6* ganglia-gmetad-3.6*"
 
 #Uninstall older version of ganglia if it was reinstalled in AMI
-yum remove -q -y httpd* php* ganglia ganglia-web ganglia-gmond ganglia-gmetad & sleep 0.3
-yum install -q -y $GANGLIA_PACKAGES
+yum remove -q -y $OLD_GANGLIA_PACKAGES & sleep 0.3
+yum install -q -y $GANGLIA_PACKAGES & sleep 0.3
 
 for node in $SLAVES $OTHER_MASTERS; do
-  ssh -t -t $SSH_OPTS root@$node "yum remove -q -y httpd* php* ganglia ganglia-web ganglia-gmond ganglia-gmetad" & sleep 0.3
+  ssh -t -t $SSH_OPTS root@$node "yum remove -q -y $OLD_GANGLIA_PACKAGES & sleep 0.3
   ssh -t -t $SSH_OPTS root@$node "yum install -q -y $GANGLIA_PACKAGES" & sleep 0.3
 done
 wait

--- a/ganglia/init.sh
+++ b/ganglia/init.sh
@@ -11,7 +11,7 @@ chown -R nobody:nobody /mnt/ganglia/rrds
 # Install ganglia
 # TODO: Remove this once the AMI has ganglia by default
 
-GANGLIA_PACKAGES="ganglia ganglia-web ganglia-gmond ganglia-gmetad"
+GANGLIA_PACKAGES="httpd24-2.4 php56-common-5.6 ganglia-3.6 ganglia-web-3.5 ganglia-gmond-3.6 ganglia-gmetad-3.6"
 
 if ! rpm --quiet -q $GANGLIA_PACKAGES; then
   yum install -q -y $GANGLIA_PACKAGES;

--- a/templates/etc/httpd/conf/httpd.conf
+++ b/templates/etc/httpd/conf/httpd.conf
@@ -196,7 +196,7 @@ LoadModule version_module modules/mod_version.so
 LoadModule unixd_module modules/mod_unixd.so
 LoadModule access_compat_module modules/mod_access_compat.so
 LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
-LoadModule php5_module modules/libphp-5.5.so
+LoadModule php5_module modules/libphp-5.6.so
 
 #
 # The following modules are not loaded by default:


### PR DESCRIPTION
Fixed libphp version to load the one available in AMI (Spark AMI: ami-5bb18832)

Fixed the issue when Ganglia is not available because:

Shutting down GANGLIA gmond: [FAILED]

Starting GANGLIA gmond: [ OK ]

Shutting down GANGLIA gmond: [FAILED]

Starting GANGLIA gmond: [ OK ]

Connection to <...> closed. <...> Stopping httpd:
[FAILED] Starting httpd: httpd: Syntax error on line 199 of /etc/httpd/conf/httpd.conf: Cannot load modules/libphp-5.5.so into server: /etc/httpd/modules/libphp-5.5.so: cannot open shared object file: No such file or directory [FAILED] [timing]

ganglia setup: 00h 00m 03s Connection to <...> closed.

Spark standalone cluster started at <...>:8080 Ganglia started at <...>:5080/ganglia

Done!
