### PR TITLE
prebuilt urls are not valid since 0.7. Should default to new scheme

### DIFF
--- a/spark/init.sh
+++ b/spark/init.sh
@@ -126,9 +126,9 @@ else
       ;;
     *)
       if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://s3.amazonaws.com/spark-related-packages/spark-$SPARK_VERSION-prebuilt-hadoop1.tgz
+        wget http://s3.amazonaws.com/spark-related-packages/spark-$SPARK_VERSION-bin-hadoop1.tgz
       elif [[ "$HADOOP_MAJOR_VERSION" == "2" ]]; then
-        wget http://s3.amazonaws.com/spark-related-packages/spark-$SPARK_VERSION-prebuilt-cdh4.tgz
+        wget http://s3.amazonaws.com/spark-related-packages/spark-$SPARK_VERSION-bin-cdh4.tgz
       else
         wget http://s3.amazonaws.com/spark-related-packages/spark-$SPARK_VERSION-bin-hadoop2.4.tgz
       fi


### PR DESCRIPTION
This script is really brittle with new versions of spark. The current release of Spark 1.4.0 breaks this because it's assumes there will be an entry for each version. If there is no version configured the script falls back to an old url scheme from 0.7. Everything since 0.7 has been standardized on a new scheme so it makes sense to instead default to the new url scheme and work for future versions.

Also the spark repo for 1.4 ec2 script is still pointed to the 1.3 branch, so even merging this pull request will not fix the problem. The spark repo also needs to be updated.
