### PR TITLE
make spark/hadoop distribution urls future proof

### DIFF
--- a/spark/init.sh
+++ b/spark/init.sh
@@ -59,6 +59,11 @@ else
       else
         wget http://s3.amazonaws.com/spark-related-packages/spark-$SPARK_VERSION-bin-cdh4.tgz
       fi
+
+      if [ $? != 0 ]; then
+        echo "ERROR: Unknown Spark version"
+        return -1
+      fi
       ;;
   esac
 

--- a/spark/init.sh
+++ b/spark/init.sh
@@ -53,93 +53,13 @@ else
         wget http://s3.amazonaws.com/spark-related-packages/spark-0.9.0-incubating-bin-cdh4.tgz
       fi
       ;;
-    0.9.1)
-      if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://s3.amazonaws.com/spark-related-packages/spark-0.9.1-bin-hadoop1.tgz
-      else
-        wget http://s3.amazonaws.com/spark-related-packages/spark-0.9.1-bin-cdh4.tgz
-      fi
-      ;;
-    0.9.2)
-      if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://s3.amazonaws.com/spark-related-packages/spark-0.9.2-bin-hadoop1.tgz
-      else
-        wget http://s3.amazonaws.com/spark-related-packages/spark-0.9.2-bin-cdh4.tgz
-      fi
-      ;;
-    1.0.0)
-      if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.0.0-bin-hadoop1.tgz
-      else
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.0.0-bin-cdh4.tgz
-      fi
-      ;;
-    1.0.1)
-      if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.0.1-bin-hadoop1.tgz
-      else
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.0.1-bin-cdh4.tgz
-      fi
-      ;;
-    1.0.2)
-      if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.0.2-bin-hadoop1.tgz
-      else
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.0.2-bin-cdh4.tgz
-      fi
-      ;;
-    1.1.0)
-      if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.1.0-bin-hadoop1.tgz
-      else
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.1.0-bin-cdh4.tgz
-      fi
-      ;;
-    1.1.1)
-      if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.1.1-bin-hadoop1.tgz
-      else
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.1.1-bin-cdh4.tgz
-      fi
-      ;;
-    1.2.0)
-      if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.2.0-bin-hadoop1.tgz
-      else
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.2.0-bin-cdh4.tgz
-      fi
-      ;;
-    1.2.1)
-      if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.2.1-bin-hadoop1.tgz
-      else
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.2.1-bin-cdh4.tgz
-      fi
-      ;;
-    1.2.2)
-      if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.2.2-bin-hadoop1.tgz
-      else
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.2.2-bin-cdh4.tgz
-      fi
-      ;;
-    1.3.0)
-      if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.3.0-bin-hadoop1.tgz
-      else
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.3.0-bin-cdh4.tgz
-      fi
-      ;;
-    1.3.1)
-      if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.3.1-bin-hadoop1.tgz
-      else
-        wget http://s3.amazonaws.com/spark-related-packages/spark-1.3.1-bin-cdh4.tgz
-      fi
-      ;;
     *)
-      echo "ERROR: Unknown Spark version"
-      return
+      if [[ "$HADOOP_MAJOR_VERSION" == "1" ]]; then
+        wget http://s3.amazonaws.com/spark-related-packages/spark-$SPARK_VERSION-bin-hadoop1.tgz
+      else
+        wget http://s3.amazonaws.com/spark-related-packages/spark-$SPARK_VERSION-bin-cdh4.tgz
+      fi
+      ;;
   esac
 
   echo "Unpacking Spark"


### PR DESCRIPTION
Spark Deploy on ec2 is broken because a specific config was not made for 1.4. I updated this code so that is uses the standard url scheme since version 1. This way it fixes it for 1.4 and all future versions until the url scheme changes in the future.
