### PR TITLE
[SPARK-8338] Ganglia fails to run because of httpd.conf configuration mismatch

### DIFF
--- a/ganglia/init.sh
+++ b/ganglia/init.sh
@@ -12,7 +12,7 @@ OLD_GANGLIA_PACKAGES="httpd* php* ganglia* ganglia* ganglia-gmond* ganglia-gmeta
 GANGLIA_PACKAGES="httpd24-2.4* php56-5.6* ganglia-3.6* ganglia-web-3.5* ganglia-gmond-3.6* ganglia-gmetad-3.6*"
 
 #Uninstalls older version of ganglia from master if it was reinstalled in AMI
-yum remove -q -y $OLD_GANGLIA_PACKAGES
+yum remove -q -y $OLD_GANGLIA_PACKAGES 2>&1 | grep -v "No Match for argument:"
 yum install -q -y $GANGLIA_PACKAGES & sleep 1
 wait
 

--- a/ganglia/init.sh
+++ b/ganglia/init.sh
@@ -8,16 +8,19 @@ rm -rf /mnt/ganglia/rrds/*
 mkdir -p /mnt/ganglia/rrds
 chown -R nobody:nobody /mnt/ganglia/rrds
 
-# Install ganglia
-# TODO: Remove this once the AMI has ganglia by default
+OLD_GANGLIA_PACKAGES="httpd* php* ganglia* ganglia* ganglia-gmond* ganglia-gmetad*"
+GANGLIA_PACKAGES="httpd24-2.4* php56-5.6* ganglia-3.6* ganglia-web-3.5* ganglia-gmond-3.6* ganglia-gmetad-3.6*"
 
-GANGLIA_PACKAGES="ganglia ganglia-web ganglia-gmond ganglia-gmetad"
+#Uninstalls older version of ganglia from master if it was reinstalled in AMI
+yum remove -q -y $OLD_GANGLIA_PACKAGES & sleep 0.3
+wait
+yum install -q -y $GANGLIA_PACKAGES & sleep 0.3
+wait
 
-if ! rpm --quiet -q $GANGLIA_PACKAGES; then
-  yum install -q -y $GANGLIA_PACKAGES;
-fi
 for node in $SLAVES $OTHER_MASTERS; do
-  ssh -t -t $SSH_OPTS root@$node "if ! rpm --quiet -q $GANGLIA_PACKAGES; then yum install -q -y $GANGLIA_PACKAGES; fi" & sleep 0.3
+  #Uninstalls older version of ganglia from other masters if it was reinstalled in AMI
+  ssh -t -t $SSH_OPTS root@$node "yum remove -q -y $OLD_GANGLIA_PACKAGES & sleep 0.3
+  ssh -t -t $SSH_OPTS root@$node "yum install -q -y $GANGLIA_PACKAGES" & sleep 0.3
 done
 wait
 

--- a/ganglia/init.sh
+++ b/ganglia/init.sh
@@ -12,8 +12,7 @@ OLD_GANGLIA_PACKAGES="httpd* php* ganglia* ganglia* ganglia-gmond* ganglia-gmeta
 GANGLIA_PACKAGES="httpd24-2.4* php56-5.6* ganglia-3.6* ganglia-web-3.5* ganglia-gmond-3.6* ganglia-gmetad-3.6*"
 
 #Uninstalls older version of ganglia from master if it was reinstalled in AMI
-yum remove -q -y $OLD_GANGLIA_PACKAGES & sleep 1
-wait
+yum remove -q -y $OLD_GANGLIA_PACKAGES
 yum install -q -y $GANGLIA_PACKAGES & sleep 1
 wait
 

--- a/ganglia/init.sh
+++ b/ganglia/init.sh
@@ -18,7 +18,7 @@ wait
 
 for node in $SLAVES $OTHER_MASTERS; do
   #Uninstalls older version of ganglia from other masters if it was reinstalled in AMI
-  ssh -t -t $SSH_OPTS root@$node "yum remove -q -y $OLD_GANGLIA_PACKAGES" & sleep 0.3
+  ssh -t -t $SSH_OPTS root@$node "yum remove -q -y $OLD_GANGLIA_PACKAGES  2>&1 | grep -v 'No Match for argument:'"
   ssh -t -t $SSH_OPTS root@$node "yum install -q -y $GANGLIA_PACKAGES" & sleep 0.3
 done
 wait

--- a/ganglia/init.sh
+++ b/ganglia/init.sh
@@ -12,14 +12,14 @@ OLD_GANGLIA_PACKAGES="httpd* php* ganglia* ganglia* ganglia-gmond* ganglia-gmeta
 GANGLIA_PACKAGES="httpd24-2.4* php56-5.6* ganglia-3.6* ganglia-web-3.5* ganglia-gmond-3.6* ganglia-gmetad-3.6*"
 
 #Uninstalls older version of ganglia from master if it was reinstalled in AMI
-yum remove -q -y $OLD_GANGLIA_PACKAGES & sleep 0.3
+yum remove -q -y $OLD_GANGLIA_PACKAGES & sleep 1
 wait
-yum install -q -y $GANGLIA_PACKAGES & sleep 0.3
+yum install -q -y $GANGLIA_PACKAGES & sleep 1
 wait
 
 for node in $SLAVES $OTHER_MASTERS; do
   #Uninstalls older version of ganglia from other masters if it was reinstalled in AMI
-  ssh -t -t $SSH_OPTS root@$node "yum remove -q -y $OLD_GANGLIA_PACKAGES & sleep 0.3
+  ssh -t -t $SSH_OPTS root@$node "yum remove -q -y $OLD_GANGLIA_PACKAGES" & sleep 0.3
   ssh -t -t $SSH_OPTS root@$node "yum install -q -y $GANGLIA_PACKAGES" & sleep 0.3
 done
 wait

--- a/ganglia/init.sh
+++ b/ganglia/init.sh
@@ -11,6 +11,10 @@ chown -R nobody:nobody /mnt/ganglia/rrds
 OLD_GANGLIA_PACKAGES="httpd* php* ganglia* ganglia* ganglia-gmond* ganglia-gmetad*"
 GANGLIA_PACKAGES="httpd24-2.4* php56-5.6* ganglia-3.6* ganglia-web-3.5* ganglia-gmond-3.6* ganglia-gmetad-3.6*"
 
+
+#block till other yum process finishes its job
+while [ -f /var/run/yum.pid ]; do sleep 1; done
+
 #Uninstalls older version of ganglia from master if it was reinstalled in AMI
 yum remove -q -y $OLD_GANGLIA_PACKAGES 2>&1 | grep -v "No Match for argument:"
 yum install -q -y $GANGLIA_PACKAGES & sleep 1

--- a/templates/etc/httpd/conf/httpd.conf
+++ b/templates/etc/httpd/conf/httpd.conf
@@ -196,7 +196,7 @@ LoadModule version_module modules/mod_version.so
 LoadModule unixd_module modules/mod_unixd.so
 LoadModule access_compat_module modules/mod_access_compat.so
 LoadModule mpm_prefork_module modules/mod_mpm_prefork.so
-LoadModule php5_module modules/libphp-5.5.so
+LoadModule php5_module modules/libphp-5.6.so
 
 #
 # The following modules are not loaded by default:


### PR DESCRIPTION
As described here AMI has preinstalled ganglia but it's version is too old, spark-ec2 has configuration for newer one.

This PR uninstall old ganglia and related packages and install's new one.

Tested - now it works.
