### PR TITLE
Handle empty worker instances

### DIFF
--- a/deploy_templates.py
+++ b/deploy_templates.py
@@ -50,11 +50,13 @@ else:
 tachyon_mb = spark_mb
 
 worker_instances_str = ""
-if os.getenv("SPARK_WORKER_INSTANCES") != "":
-  worker_instances_str = "%d" % int(os.getenv("SPARK_WORKER_INSTANCES", 1))
+worker_cores = slave_cpus
 
-# Distribute equally cpu cores among worker instances
-worker_cores = max(slave_cpus / worker_instances, 1)
+if os.getenv("SPARK_WORKER_INSTANCES") != "":
+  worker_instances = int(os.getenv("SPARK_WORKER_INSTANCES", 1))
+  worker_instances_str = "%d" % worker_instances
+  # Distribute equally cpu cores among worker instances
+  worker_cores = max(slave_cpus / worker_instances, 1)
 
 template_vars = {
   "master_list": os.getenv("MASTERS"),

--- a/deploy_templates.py
+++ b/deploy_templates.py
@@ -49,7 +49,10 @@ else:
 # Make tachyon_mb as spark_mb for now.
 tachyon_mb = spark_mb
 
-worker_instances = int(os.getenv("SPARK_WORKER_INSTANCES", 1))
+worker_instances_str = ""
+if os.getenv("SPARK_WORKER_INSTANCES") != "":
+  worker_instances_str = "%d" % int(os.getenv("SPARK_WORKER_INSTANCES", 1))
+
 # Distribute equally cpu cores among worker instances
 worker_cores = max(slave_cpus / worker_instances, 1)
 
@@ -61,7 +64,7 @@ template_vars = {
   "mapred_local_dirs": os.getenv("MAPRED_LOCAL_DIRS"),
   "spark_local_dirs": os.getenv("SPARK_LOCAL_DIRS"),
   "default_spark_mem": "%dm" % spark_mb,
-  "spark_worker_instances": "%d" %  worker_instances,
+  "spark_worker_instances": worker_instances_str,
   "spark_worker_cores": "%d" %  worker_cores,
   "spark_master_opts": os.getenv("SPARK_MASTER_OPTS", ""),
   "spark_version": os.getenv("SPARK_VERSION"),


### PR DESCRIPTION
In YARN mode we clear the `SPARK_WORKER_INSTANCES` env variable in spark_ec2.py. However this leads to an error as the code path tries to evaluate `int("")`. 

This PR adds a check for the empty string.

cc @andrewor14
