### PR TITLE
Return positive value on error

### DIFF
--- a/ephemeral-hdfs/init.sh
+++ b/ephemeral-hdfs/init.sh
@@ -41,7 +41,7 @@ case "$HADOOP_MAJOR_VERSION" in
 
   *)
      echo "ERROR: Unknown Hadoop version"
-     return -1
+     return 1
 esac
 cp /root/hadoop-native/* ephemeral-hdfs/lib/native/
 /root/spark-ec2/copy-dir /root/ephemeral-hdfs

--- a/persistent-hdfs/init.sh
+++ b/persistent-hdfs/init.sh
@@ -40,7 +40,7 @@ case "$HADOOP_MAJOR_VERSION" in
 
   *)
      echo "ERROR: Unknown Hadoop version"
-     return -1
+     return 1
 esac
 cp /root/hadoop-native/* /root/persistent-hdfs/lib/native/
 /root/spark-ec2/copy-dir /root/persistent-hdfs


### PR DESCRIPTION
I spotted this in the `spark-ec2` output:

```
Initializing ephemeral-hdfs
ERROR: Unknown Hadoop version
ephemeral-hdfs/init.sh: line 33: return: -1: invalid option
return: usage: return [n]
cp: target `ephemeral-hdfs/lib/native/' is not a directory
File or directory /root/ephemeral-hdfs doesn't exist!
[timing] ephemeral-hdfs init:  00h 00m 00s
```

(I specified `yarn` for Hadoop version, but used Spark 1.3.)
